### PR TITLE
Bug fixes in support.py on ReadablePathHandler

### DIFF
--- a/reem/supports.py
+++ b/reem/supports.py
@@ -51,7 +51,7 @@ class ReadablePathHandler(PathHandler):
     def read(self):
         server_value = self.reader.read_from_redis(self.path)
         if type(server_value)==dict and _ROOT_VALUE_READ_NAME in server_value:
-            return server_value[root_value_read_name]
+            return server_value[_ROOT_VALUE_READ_NAME]
         return server_value
 
 


### PR DESCRIPTION
Small typo on ReadablePathHandler (root_value_read_name -> _ROOT_VALUE_READ_NAME would cause nested keys to not be parsed correctly.