### PR TITLE
Pass arguments through to the Redis Interface

### DIFF
--- a/reem/compat.py
+++ b/reem/compat.py
@@ -12,7 +12,9 @@ if redis.__version__ >= '4.0.0':
         def __init__(self,r):
             self._r = r
         def __getattr__(self,attr):
-            if attr.startswith('json'):
+            if attr == "jsondel":
+                return self._r.delete
+            elif attr.startswith('json'):
                 return getattr(self._r.json(),attr[4:])
             return getattr(self._r,attr)
         def __enter__(self):

--- a/reem/compat.py
+++ b/reem/compat.py
@@ -15,6 +15,10 @@ if redis.__version__ >= '4.0.0':
             if attr.startswith('json'):
                 return getattr(self._r.json(),attr[4:])
             return getattr(self._r,attr)
+        def __enter__(self):
+            return self._r.__enter__()
+        def __exit__(self, *args, **kwargs):
+            return self._r.__exit__(*args, **kwargs)
         def pipeline(self):
             return RejsonCompat(self._r.pipeline())
 

--- a/reem/compat.py
+++ b/reem/compat.py
@@ -22,10 +22,10 @@ if redis.__version__ >= '4.0.0':
         def pipeline(self):
             return RejsonCompat(self._r.pipeline())
 
-    def make_redis_client(host='localhost',port=6379,db=0):
+    def make_redis_client(host='localhost',port=6379,db=0,*args,**kwargs):
         """Return plain redis client + rejson client"""
-        r = redis.Redis(host,port=port,db=db)
-        j = RejsonCompat(redis.Redis(host,port=port,db=db))
+        r = redis.Redis(host,port=port,db=db,*args,**kwargs)
+        j = RejsonCompat(redis.Redis(host,port=port,db=db,*args,**kwargs))
         return r,j
 else:
     #versions < 4.0.0 don't have rejson built in
@@ -34,8 +34,8 @@ else:
 
     ROOT_PATH = Path.rootPath()
 
-    def make_redis_client(host='localhost',port=6379,db=0):
+    def make_redis_client(host='localhost',port=6379,db=0,*args,**kwargs):
         """Return plain redis client + rejson client"""
-        r = rejson.Client(host=host, port=port, db=db, decode_responses=False)
-        j = rejson.Client(host=host, port=port, db=db, decode_responses=True)
+        r = rejson.Client(host=host, port=port, db=db, decode_responses=False, *args, **kwargs)
+        j = rejson.Client(host=host, port=port, db=db, decode_responses=True, *args, **kwargs)
         return r,j

--- a/reem/connection.py
+++ b/reem/connection.py
@@ -45,6 +45,12 @@ class KeyValueStore(object):
     but produces ``KeyAccessor`` objects that assist with path
     construction and call the reader and writer's write and read methods.
 
+    When constructing this class, users can pass through ``*args`` and
+    ``**kwargs`` that will be forwarded to the ``RedisInterface`` and
+    eventually to the ``Redis`` client. This allows users to set things like
+    socket timeouts. See https://redis.readthedocs.io/en/latest/connections.html
+    for a full list of options.
+
     Attributes:
         interface (str, RedisInterface, or KeyValueStore): Defines the
         connection to Redis this reader will use. If a str, then a

--- a/reem/connection.py
+++ b/reem/connection.py
@@ -13,10 +13,10 @@ class RedisInterface:
     """
 
     """
-    def __init__(self, host='localhost', marshallers=[NumpyMarshaller()]):
+    def __init__(self, host='localhost', marshallers=[NumpyMarshaller()], *args, **kwargs):
         self.hostname = host
         self.marshallers = marshallers
-        self.client_no_decode,self.client = make_redis_client(host)
+        self.client_no_decode,self.client = make_redis_client(host, *args, **kwargs)
         metadata_client = redis.Redis(host)
         self.metadata_listener = MetadataListener(metadata_client)
         self.INTERFACE_LOCK = Lock()
@@ -50,10 +50,10 @@ class KeyValueStore(object):
         connection to Redis this reader will use. If a str, then a
         RedisInterface will be created and connected to automatically.
     """
-    def __init__(self, interface='localhost'):
+    def __init__(self, interface='localhost', *args, **kwargs):
         if isinstance(interface,str):
             host = interface
-            self.interface = RedisInterface(host)
+            self.interface = RedisInterface(host, *args, **kwargs)
         elif isinstance(interface,KeyValueStore):
             self.interface = interface.interface
             assert isinstance(self.interface,RedisInterface)


### PR DESCRIPTION
Allows users to configure the redis interface to control parameters like socket timeouts.

Also added `__enter__` and `__exit__` functions to `RejsonCompat` so that pipelines can be used in `with` blocks.

Closes #4.